### PR TITLE
Initial patch for the metric selection bug

### DIFF
--- a/static-content/MetricControlCtrl.js
+++ b/static-content/MetricControlCtrl.js
@@ -398,7 +398,6 @@ aardvark.directive('tagSelection', function() {
     $scope.metricSelected = function(metricName, newMetric) {
         $scope.tagOptions = {};
         $scope.tag = {};
-        $scope.resetUserMetricOptions();
         var url = $rootScope.config.tsdbProtocol+"://"+$rootScope.config.tsdbHost+":"+$rootScope.config.tsdbPort+"/api/search/lookup";
         var requestJson = {"metric": metricName, "limit": 100000, "useMeta": true}; // todo: useMeta should be based on tsdb config
         var postData = JSON.stringify(requestJson);


### PR DESCRIPTION
I was trying to use aardvark today and was unable to draw any graphs. I think that the options are being reset either erroneously or too early. This very quick fix allows graphs to be drawn. I don't know whether edge-case functionality is affected by this change. I have done this purely online and so haven't ran any of the tests (although if this causes the tests to fail but an inability to draw graphs does not then I would argue that new tests are needed).